### PR TITLE
Adding safaricom receipt number in conformation api

### DIFF
--- a/src/main/java/org/mifos/connector/ams/paygops/zeebe/ZeebeVariables.java
+++ b/src/main/java/org/mifos/connector/ams/paygops/zeebe/ZeebeVariables.java
@@ -8,6 +8,6 @@ public class ZeebeVariables {
     public static final String TRANSACTION_ID = "transactionId";
     public static final String PARTY_LOOKUP_FAILED = "partyLookupFailed";
     public static final String TRANSFER_SETTLEMENT_FAILED = "transferSettlementFailed";
-    public static final String SERVER_TRANSACTION_ID = "mpesaTransactionId";
+    public static final String SERVER_TRANSACTION_RECEIPT_NUMBER = "mpesaReceiptNumber";
     public static final String AMS_REQUEST = "amsRequest";
 }

--- a/src/main/java/org/mifos/connector/ams/paygops/zeebe/ZeebeWorkers.java
+++ b/src/main/java/org/mifos/connector/ams/paygops/zeebe/ZeebeWorkers.java
@@ -95,11 +95,9 @@ public class ZeebeWorkers {
 
                         JSONObject channelRequest = new JSONObject((String) variables.get("channelRequest"));
                         String transactionId = (String) variables.get(TRANSACTION_ID);
-
+                        ex.setProperty(TRANSACTION_ID, variables.getOrDefault(SERVER_TRANSACTION_RECEIPT_NUMBER, transactionId));
                         ex.setProperty(CHANNEL_REQUEST, channelRequest);
                         logger.info("Channel Request :" + ex.getProperty(CHANNEL_REQUEST));
-                        ex.setProperty(TRANSACTION_ID, transactionId);
-
                         producerTemplate.send("direct:transfer-settlement", ex);
                         boolean isSettlementFailed = ex.getProperty(TRANSFER_SETTLEMENT_FAILED, boolean.class);
                         variables.put(ZeebeVariables.AMS_REQUEST,ex.getProperty(AMS_REQUEST));


### PR DESCRIPTION
On successful Mpesa API call, take the Safaricom generated receipt number to confirmation api call


@avikganguly01 : Please review