### PR TITLE
Fix for repsonse body parsing error for version 1.0.3

### DIFF
--- a/src/main/java/org/mifos/connector/ams/paygops/paygopsDTO/PaygopsResponseDto.java
+++ b/src/main/java/org/mifos/connector/ams/paygops/paygopsDTO/PaygopsResponseDto.java
@@ -1,6 +1,8 @@
 package org.mifos.connector.ams.paygops.paygopsDTO;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 public class PaygopsResponseDto {
 
@@ -59,7 +61,7 @@ public class PaygopsResponseDto {
     private String destination_type;
 
     @JsonProperty("destinations")
-    private String [] destinations = new String[1];
+    private Object[] destinations = new Object[1];
 
     @Override
     public String toString() {
@@ -171,11 +173,11 @@ public class PaygopsResponseDto {
         this.destination_type = destination_type;
     }
 
-    public String[] getDestinations() {
+    public Object[] getDestinations() {
         return destinations;
     }
 
-    public void setDestination(String[] destinations) {
+    public void setDestination(Object[] destinations) {
         this.destinations = destinations;
     }
 }


### PR DESCRIPTION
## Description

* Paygops v1.0.3 was producing following error:
` Body could not be passed due to : com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `[Ljava.lang.String;` from Object value (token `JsonToken.START_OBJECT`)
 at [Source: (String)"{"transaction_id": "148e6800a47fBHAtWbmJ", "amount": "2", "sender_name": "254797668592", "sender_phone_number": "+254797668592", "sent_datetime": "2022-10-24T06:43:05.105839Z", "memo": "24322607", "wallet_operator": "MPESA", "country": "KE", "currency": "USD", "warnings": [], "reconciled": true, "destinations": [{"destination_type": "contract_repayment", "destination": "C370015"}], "destination_type": "contract_repayment", "destination": "C370015"}
"; line: 1, column: 315] (through reference chain: org.mifos.connector.ams.paygops.paygopsDTO.PaygopsResponseDto["destinations"]->java.lang.Object[][0]) `

This PR contains the fix for the same.

Main points of the PR:
- The error was coming due to wrong data type of destinations field coming in response body.
- The response unmarshaling was also faulty. 
- Fixed both here and tested it.

 _(Ignore if these details are present on the associated JIRA ticket)_

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Design related bullet points or design document link related to this PR added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [x] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [x] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing



@avikganguly01 @fynmanoj : Please review and release 1.0.4 
